### PR TITLE
Make Icon Look Better

### DIFF
--- a/octoprint_tasmota/static/css/tasmota.css
+++ b/octoprint_tasmota/static/css/tasmota.css
@@ -1,13 +1,18 @@
 #navbar_plugin_tasmota > a > i.on {
-	color: #00FF00 !important;
+	color: #ffffffff !important;
 }
 
 #navbar_plugin_tasmota > a > i.off {
-	color: #FF0000 !important;
+	color: #ffffff77 !important;
 }
 
 #navbar_plugin_tasmota > a > i.unknown {
-	color: #808080 !important;
+	color: #ffffff44 !important;
+}
+
+#navbar_plugin_tasmota > a > i.unknown::after {
+	content: " ?";
+	font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 #navbar_plugin_tasmota > a > div.tasmota_label {

--- a/octoprint_tasmota/static/css/tasmota.css
+++ b/octoprint_tasmota/static/css/tasmota.css
@@ -10,6 +10,24 @@
 	color: #ffffff44 !important;
 }
 
+.navbar-inner.default #navbar_plugin_tasmota > a > i.on,
+.navbar-inner.white #navbar_plugin_tasmota > a > i.on,
+.navbar-inner.green #navbar_plugin_tasmota > a > i.on {
+	color: #333333ff !important;
+}
+
+.navbar-inner.default #navbar_plugin_tasmota > a > i.off,
+.navbar-inner.white #navbar_plugin_tasmota > a > i.off,
+.navbar-inner.green #navbar_plugin_tasmota > a > i.off {
+	color: #3337 !important;
+}
+
+.navbar-inner.default #navbar_plugin_tasmota > a > i.unknown,
+.navbar-inner.white #navbar_plugin_tasmota > a > i.unknown,
+.navbar-inner.green #navbar_plugin_tasmota > a > i.unknown {
+	color: #33333344 !important;
+}
+
 #navbar_plugin_tasmota > a > i.unknown::after {
 	content: " ?";
 	font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.8.5"
+plugin_version = "0.8.6"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
I think that the red and green for the icon is an eyesore, so I propose that the icon change transparency instead of change color to symbolize the status.

100% White (`#ffff`) would be On
47% White (`#fff7`) would be Off
and 27% White (`#ff4`) with a `?` would be Unknown