### PR TITLE
1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ Once installed go into settings and enter the ip address for your TP-Link Smartp
   With these options the raspberry pi will be shutdown 5 seconds after the idle timeout is reached (as configured on the main settings page) and send a backlog command to your Tasmota device to power off after a 60 second delay.
 
 ## Most recent changelog
-**[1.0.2](https://github.com/jneilliii/OctoPrint-Tasmota/releases/tag/1.0.0)** (04/09/2021)
-* add uptime library to resolve issues with idle timeout and initial pi boot
-* add label to warning prompts for better identification
-* resolve issues related to thermal runaway only being triggered once until a restart
-* add LED control via [M150](https://reprap.org/wiki/G-code#M150:_Set_LED_color) gcode commands
+**[1.0.4](https://github.com/jneilliii/OctoPrint-Tasmota/releases/tag/1.0.4)** (07/31/2021)
+* fix bug with M150 command not having I parameter causing the command to get lost in the queue, #143
+* make request timeout configurable in settings, #142
+* add numeric StatusSTS messages for chk values, #150
+* M118 support for LED commands for more real-time control based on what's happening on the printer (ie waiting for heat up). The function is similar to the M150 support but you will need to use the command `M118 TASMOTA_M150 I192.168.0.105 R### G### B### W### P###`
+* account for energy data with multiple relay device, #155
 
 ### [All releases](https://github.com/jneilliii/OctoPrint-Tasmota/releases)
 

--- a/octoprint_tasmota/__init__.py
+++ b/octoprint_tasmota/__init__.py
@@ -720,6 +720,7 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 						else:
 							return
 			elif gcode == "M150":
+				plugip = None
 				workleds = dict(LEDRed=0, LEDBlue=0, LEDGreen=0, LEDWhite=0, LEDBrightness=-1)
 				workval = cmd.upper().split()
 				for i in workval:
@@ -746,9 +747,10 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 					else:
 						self._tasmota_logger.debug(leddata)
 
-				t = threading.Timer(0, self.gcode_led, [plugip, workleds])
-				t.daemon = True
-				t.start()
+				if plugip is not None:
+					t = threading.Timer(0, self.gcode_led, [plugip, workleds])
+					t.daemon = True
+					t.start()
 			elif self.powerOffWhenIdle and not (gcode in self._idleIgnoreCommandsArray):
 				self._waitForHeaters = False
 				self._reset_idle_timer()

--- a/octoprint_tasmota/__init__.py
+++ b/octoprint_tasmota/__init__.py
@@ -451,7 +451,7 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 
 		self._tasmota_logger.debug("Response: %s" % response)
 
-		if chk.upper() == "ON":
+		if chk.upper() in ["ON", "1"]:
 			if plug["autoConnect"] and self._printer.is_closed_or_error():
 				self._logger.info(self._settings.global_get(['serial']))
 				c = threading.Timer(int(plug["autoConnectDelay"]), self._printer.connect,
@@ -495,8 +495,8 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 				webresponse = requests.get("http://{}/cm".format(plugip), params={"user": plug["username"], "password": plug["password"], "cmnd": "Power{} off".format(plug["idx"])}, timeout=self._settings.get_int(["request_timeout"]))
 				response = webresponse.json()
 			chk = response["POWER%s" % plug["idx"]]
-			if chk.upper() == "OFF":
-				self._plugin_manager.send_plugin_message(self._identifier, dict(currentState="off",ip=plugip,idx=plugidx))
+			if chk.upper() in ["OFF", "0"]:
+				self._plugin_manager.send_plugin_message(self._identifier, dict(currentState="off", ip=plugip, idx=plugidx))
 		except:
 			self._tasmota_logger.error('Invalid ip or unknown error connecting to %s.' % plug["ip"], exc_info=True)
 			response = "Unknown error turning off %s index %s." % (plugip, plugidx)
@@ -561,9 +561,9 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 				sensor_data = None
 
 			self._tasmota_logger.debug("%s index %s is %s" % (plugip, plugidx, chk))
-			if chk.upper() == "ON":
+			if chk.upper() in ["ON", "1"]:
 				response = {"currentState": "on", "ip": plugip, "idx": plugidx, "energy_data": energy_data, "sensor_data": sensor_data}
-			elif chk.upper() == "OFF":
+			elif chk.upper() in ["OFF", "0"]:
 				response = {"currentState": "off", "ip": plugip, "idx": plugidx, "energy_data": energy_data, "sensor_data": sensor_data}
 			else:
 				self._tasmota_logger.debug(response)

--- a/octoprint_tasmota/__init__.py
+++ b/octoprint_tasmota/__init__.py
@@ -2,9 +2,9 @@
 from __future__ import absolute_import
 
 import octoprint.plugin
-from octoprint.access.permissions import Permissions, ADMIN_GROUP, USER_GROUP
+from octoprint.access.permissions import Permissions, ADMIN_GROUP
 from octoprint.util import RepeatedTimer
-from octoprint.events import eventManager, Events
+from octoprint.events import Events
 from flask_babel import gettext
 import time
 import logging
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 
 try:
 	from octoprint.util import ResettableTimer
-except:
+except ImportError:
 	class ResettableTimer(threading.Thread):
 		def __init__(self, interval, function, args=None, kwargs=None, on_reset=None, on_cancelled=None):
 			threading.Thread.__init__(self)
@@ -644,7 +644,7 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 			self._tasmota_logger.debug("Restarting idle timer.")
 			self._reset_idle_timer()
 		elif command == 'getEnergyData':
-			self._logger.info(data);
+			self._logger.info(data)
 			response = {}
 			if "start_date" in data and data["start_date"] != "":
 				start_date = data["start_date"]

--- a/octoprint_tasmota/__init__.py
+++ b/octoprint_tasmota/__init__.py
@@ -526,10 +526,19 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 				if energy_data is not None:
 					today = datetime.today()
 					c = self.lookup(response, *["StatusSNS", "ENERGY", "Current"])
+					if isinstance(c, list):
+						c = c[int(plugidx)-1]
 					p = self.lookup(response, *["StatusSNS", "ENERGY", "Power"])
+					if isinstance(p, list):
+						p = p[int(plugidx)-1]
 					t = self.lookup(response, *["StatusSNS", "ENERGY", "Total"])
+					if isinstance(t, list):
+						t = t[int(plugidx)-1]
 					v = self.lookup(response, *["StatusSNS", "ENERGY", "Voltage"])
+					if isinstance(v, list):
+						v = v[int(plugidx)-1]
 					self._tasmota_logger.debug("Energy Data: %s" % energy_data)
+					self._logger.debug("Inserting data: {} : {}".format(["ip", "idx", "timestamp", "current", "power", "total", "voltage"], [plugip, plugidx, today.isoformat(' '), c, p, t, v]))
 					db = sqlite3.connect(self.energy_db_path)
 					cursor = db.cursor()
 					cursor.execute(

--- a/octoprint_tasmota/templates/tasmota_settings.jinja2
+++ b/octoprint_tasmota/templates/tasmota_settings.jinja2
@@ -125,8 +125,19 @@
 			<div class="control-group span6">
 				<label class="control-label">{{ _('Cost per kWh') }}</label>
 				<div class="controls">
-					<input type="number" title="{{ _('Amount used to multiply total kWh by to estimate power cost. Leave 0 if you do not have a power reporting device.') }}" data-toggle="tooltip" min="0" step="0.1" class="input input-mini" data-bind="value: settings.settings.plugins.tasmota.cost_rate" />
+					<input type="number" title="{{ _('Amount used to multiply total kWh by to estimate power cost. Leave 0 if you do not have a power reporting device.') }}" data-toggle="tooltip" min="0" step="0.1" class="input input-mini" data-bind="value: settings.settings.plugins.tasmota.cost_rate, tooltip: {}" />
 				</div>
+			</div>
+		</div>
+		<div class="row-fluid">
+			<div class="control-group span6">
+				<label class="control-label">{{ _('Request Timeout') }}</label>
+				<div class="controls">
+                    <div class="input-append" data-toggle="tooltip" data-bind="tooltip: {}" title="{{ _('How many seconds to wait for responses from tasmota device before it is considered offline.') }}">
+					    <input type="number" min="3" class="input input-mini" data-bind="value: settings.settings.plugins.tasmota.request_timeout" />
+                        <span class="add-on">{{ _('secs') }}</span>
+                    </div>
+                </div>
 			</div>
 		</div>
 		<div class="row-fluid">

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,9 @@
 ###
 
 .
+
+setuptools
+OctoPrint
+requests
+Flask
+uptime

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.4rc4"
+plugin_version = "1.0.4rc5"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.3"
+plugin_version = "1.0.4rc1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.4rc5"
+plugin_version = "1.0.4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.4rc2"
+plugin_version = "1.0.4rc3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.4rc1"
+plugin_version = "1.0.4rc2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.4rc3"
+plugin_version = "1.0.4rc4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
* fix bug with M150 command not having I parameter causing the command to get lost in the queue, closes #143
* make request timeout configurable in settings, closes #142
* add numeric StatusSTS messages for chk values, closes #150
* account for energy data with multiple relay device, closes #155
* M118 support for LED commands for more real-time control based on what's happening on the printer (ie waiting for heat up). The function is similar to the M150 support but you will need to use the command `M118 TASMOTA_M150 I192.168.0.105 R### G### B### W### P###`