### PR TITLE
1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ Once installed go into settings and enter the ip address for your TP-Link Smartp
   With these options the raspberry pi will be shutdown 5 seconds after the idle timeout is reached (as configured on the main settings page) and send a backlog command to your Tasmota device to power off after a 60 second delay.
 
 ## Most recent changelog
-**[1.0.2](https://github.com/jneilliii/OctoPrint-Tasmota/releases/tag/1.0.0)** (04/09/2021)
-* add uptime library to resolve issues with idle timeout and initial pi boot
-* add label to warning prompts for better identification
-* resolve issues related to thermal runaway only being triggered once until a restart
-* add LED control via [M150](https://reprap.org/wiki/G-code#M150:_Set_LED_color) gcode commands
+**[1.0.4](https://github.com/jneilliii/OctoPrint-Tasmota/releases/tag/1.0.4)** (07/31/2021)
+* fix bug with M150 command not having I parameter causing the command to get lost in the queue, #143
+* make request timeout configurable in settings, #142
+* add numeric StatusSTS messages for chk values, #150
+* M118 support for LED commands for more real-time control based on what's happening on the printer (ie waiting for heat up). The function is similar to the M150 support but you will need to use the command `M118 TASMOTA_M150 I192.168.0.105 R### G### B### W### P###`
+* account for energy data with multiple relay device, #155
 
 ### [All releases](https://github.com/jneilliii/OctoPrint-Tasmota/releases)
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Once installed go into settings and enter the ip address for your TP-Link Smartp
     - When enabled if printer becomes disconnected relays with the option enabled will be automatically powered off.
   - **Upload Event Monitoring**
     - When enabled auto power on enabled devices when file is uploaded to OctoPrint with the option to automatically start printing.
+    - **Include uploads via web interface**
+      - Enable to auto power on when uploading via the web interface rather than from a Slicer with the option to automatically start.
+      - **Automtically start print after on**
+        - Enable to automatically start the print after the Tasmota device is powered on and printer auto connects.
   - **Connect Event Monitoring**
     - When enabled auto power on enabled devices when the Connect button is pressed in OctoPrint.
   - **Enable polling of status.**

--- a/README.md
+++ b/README.md
@@ -27,33 +27,112 @@ Once installed go into settings and enter the ip address for your TP-Link Smartp
 
 ## Settings Explained
 
-- **Device**
-  - The ip or hostname of tasmota device.
-- **Index**
-  - Index number reprensenting the relay to control. Leave blank for single relay devices.
-- **Icon**
-  - Icon class name from the [fontawesome](https://fontawesome.com/v3.2.1/icons/) library.
-- **Label**
-  - Title attribute on icon that shows on mouseover.
-- **Username**
-  - Username to connect to web interface.  Currently not configurable in Tasmota, use the default username admin.
-- **Password**
-  - Password configured for Web Admin Portal of Tasmota device.
-- **Warn**
-  - The left checkbox will always warn when checked.
-  - The right checkbox will only warn when printer is printing.
-- **GCODE**
-  - When checked this will enable the processing of M80 and M81 commands from gcode to power on/off plug.  Syntax for gcode command is M80/M81 followed by hostname/ip and index.  For example if your plug is 192.168.1.2 and index of 1 your gcode command would be **M80 192.168.1.2 1**
-- **postConnect**
-  - Automatically connect to printer after plug is powered on.
-  - Will wait for number of seconds configured in **Auto Connect Delay** setting prior to attempting connection to printer.
-- **preDisconnect**
-  - Automatically disconnect printer prior to powering off the plug.
-  - Will wait for number of seconds configured in **Auto Disconnect Delay** prior to powering off the plug.
-- **Cmd On**
-  - When checked will run system command configured in **System Command On** setting after a delay in seconds configured in **System Command On Delay**.
-- **Cmd Off**
-  - When checked will run system command configured in **System Command Off** setting after a delay in seconds configured in **System Command Off Delay**.
+- ### General
+  - **Enable thermal runaway monitoring.**
+    - When enabled if temperatures exceed configured maximums enabled relay will be powered off.
+    - **Max Bed Temp**
+      - Maximum temperature bed can reach before automatic power off is triggered.
+    - **Max Extruder Temp**
+      - Maximum temperature extruders can reach before automatic power off is triggered.
+  - **Error Event Monitoring**
+    - When enabled if printer reports an error relays with the option enabled will be automatically powered off.
+  - **Disconnect Event Monitoring**
+    - When enabled if printer becomes disconnected relays with the option enabled will be automatically powered off.
+  - **Upload Event Monitoring**
+    - When enabled auto power on enabled devices when file is uploaded to OctoPrint with the option to automatically start printing.
+  - **Connect Event Monitoring**
+    - When enabled auto power on enabled devices when the Connect button is pressed in OctoPrint.
+  - **Enable polling of status.**
+    - When enabled the status of relays will be checked based on the Polling Interval supplied.
+    - **Polling Interval**
+      - How many minutes between status checks of all relays when polling is enabled.
+  - **Cost per kWh**
+    - Amount used to multiply total kWh by to estimate power cost. Leave 0 if you do not have a power reporting device.
+  - **Request Timeout**
+    - How many seconds to wait for responses from tasmota device before it is considered offline.
+  - **Enable debug logging.**
+    - Report additional information in plugin_tasmota_debug.log for troubleshooting.
+  - **Power Off on Idle**
+    - Automatically power off all relays with the option Off on Idle enabled after configured idle timeout, target tempoerature is reached, and timelapse is completed.
+    - **Abort Power Off Timeout**
+      - Pop up will be displayed for this amount of time in seconds to allow for delaying power off of relays.
+    - **Idle Timeout**
+      - Amount of time that will lapse before printer is considered idle and relays will be powered off.
+    - **Idle Target Temperature**
+      - Power off will be delayed until all heaters reach this temperature.
+    - **GCode Commands to Ignore for Idle**
+      - Comma separated list of gcode commands to ignore for determining printer idle state.
+    - **Wait for Timelapse**
+      - When enabled idle power off will wait for timelapse to complete before powering off. Uncheck this to not wait, helpful for very long prints and timelapse rendering.
+- ### Device Specific
+  - **IP**
+    - The ip or hostname of tasmota device.
+  - **Index**
+    - Index of the relay, specifically used for multiple plug relay devices. Leave blank for single relay devices.
+  - **Label**
+    - Name to display on hover of the navbar button.
+  - **Username**
+    - Username to connect to web interface. Currently, not configurable in Tasmota, use the default username admin.
+  - **Password**
+    - Password configured for Web Admin Portal of Tasmota device.
+  - **Verify**
+    - Use this button to make sure that the plugin can communicate with your Tasmota device.
+  - **On Color**
+    - Color to display when device is on.
+  - **Off Color**
+    - Color to display when device is off.
+  - **Unknown Color**
+    - Color to display when device status is unknown.
+  - **Icon Class**
+    - Icon class name from the [fontawesome](https://fontawesome.com/icons?d=gallery&m=free) library.
+  - **LED**
+    - Is an LED or WS2812 type device connected, enter brightness value as percentage.
+  - **Sensor Identifier**
+    - Sensor identifier for connected sensors, ie DHT11 or BME280
+  - **On with Upload**
+    - Automatically power on when file is uploaded with the option to start printing automatically.
+  - **On with Connect**
+    - Automatically power on when pressing Connect button.
+  - **Off on Idle**
+    - Automatically power off when printer is idle.
+  - **Thermal Runaway**
+    - Power off if temperature exceeds configured max temperatures.
+  - **Off on Error**
+    - Automatically power off this relay when Error Event Monitoring is enabled.
+  - **Off on Disconnect**
+    - Automatically power off this relay when Disconnect Event Monitoring is enabled.
+  - **Auto Connect**
+    - Automatically connect to your printer after configured delay from power on.
+  - **Auto Disconnect**
+    - Automatically disconnect from printer and then power off relay after configured delay.
+  - **Warning Prompt**
+    - Prompt for confirmation before powering off via the navbar button.
+  - **Warn While Printing**
+    - Prompt for confirmation before powering off when a print is active.
+  - **Use Countdown Timers**
+    - Use Tasmota's built-in countdown functionality to offload the power operations. Helpful for safe shutdown of pi.
+    - **On Delay Countdown**
+      - Amount of delay in seconds for powering on device.
+    - **Off Delay Countdown**
+      - Amount of delay in seconds for powering off device.
+  - **GCODE On / Off Trigger**
+      - When checked this will enable the processing of M80 and M81 commands from gcode to power on/off plug.  Syntax for gcode command is M80/M81 followed by hostname/ip and index.  For example if your plug is 192.168.1.2 and index of 1 your gcode command would be **M80 192.168.1.2 1**
+      - **GCODE On Delay**
+        - Amount of delay in seconds before powering on device.
+      - **GCODE Off Delay**
+        - Amount of delay in seconds for powering off device.
+  - **Run System Command After On**
+    - When checked will run the system command configured in setting below after sending on command to device.
+    - **System Command to Run**
+      - System command to run after the on command is sent to device.
+    - **Delay**
+      - Delay in seconds before system command is run.
+  - **Run System Command Before Off**
+    - When checked will run the system command configured in setting below before sending off command to device.
+    - **System Command to Run**
+      - System command to run before the on command is sent to device.
+    - **Delay**
+      - Delay in seconds after system command is run before powering off device.
 
 ## Examples
 

--- a/octoprint_tasmota/__init__.py
+++ b/octoprint_tasmota/__init__.py
@@ -720,6 +720,7 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 						else:
 							return
 			elif gcode == "M150":
+				plugip = None
 				workleds = dict(LEDRed=0, LEDBlue=0, LEDGreen=0, LEDWhite=0, LEDBrightness=-1)
 				workval = cmd.upper().split()
 				for i in workval:
@@ -746,9 +747,10 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 					else:
 						self._tasmota_logger.debug(leddata)
 
-				t = threading.Timer(0, self.gcode_led, [plugip, workleds])
-				t.daemon = True
-				t.start()
+				if plugip is not None:
+					t = threading.Timer(0, self.gcode_led, [plugip, workleds])
+					t.daemon = True
+					t.start()
 			elif self.powerOffWhenIdle and not (gcode in self._idleIgnoreCommandsArray):
 				self._waitForHeaters = False
 				self._reset_idle_timer()

--- a/octoprint_tasmota/__init__.py
+++ b/octoprint_tasmota/__init__.py
@@ -451,7 +451,7 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 
 		self._tasmota_logger.debug("Response: %s" % response)
 
-		if chk.upper() == "ON":
+		if chk.upper() in ["ON", "1"]:
 			if plug["autoConnect"] and self._printer.is_closed_or_error():
 				self._logger.info(self._settings.global_get(['serial']))
 				c = threading.Timer(int(plug["autoConnectDelay"]), self._printer.connect,
@@ -495,8 +495,8 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 				webresponse = requests.get("http://{}/cm".format(plugip), params={"user": plug["username"], "password": plug["password"], "cmnd": "Power{} off".format(plug["idx"])}, timeout=self._settings.get_int(["request_timeout"]))
 				response = webresponse.json()
 			chk = response["POWER%s" % plug["idx"]]
-			if chk.upper() == "OFF":
-				self._plugin_manager.send_plugin_message(self._identifier, dict(currentState="off",ip=plugip,idx=plugidx))
+			if chk.upper() in ["OFF", "0"]:
+				self._plugin_manager.send_plugin_message(self._identifier, dict(currentState="off", ip=plugip, idx=plugidx))
 		except:
 			self._tasmota_logger.error('Invalid ip or unknown error connecting to %s.' % plug["ip"], exc_info=True)
 			response = "Unknown error turning off %s index %s." % (plugip, plugidx)
@@ -561,9 +561,9 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 				sensor_data = None
 
 			self._tasmota_logger.debug("%s index %s is %s" % (plugip, plugidx, chk))
-			if chk.upper() == "ON":
+			if chk.upper() in ["ON", "1"]:
 				response = {"currentState": "on", "ip": plugip, "idx": plugidx, "energy_data": energy_data, "sensor_data": sensor_data}
-			elif chk.upper() == "OFF":
+			elif chk.upper() in ["OFF", "0"]:
 				response = {"currentState": "off", "ip": plugip, "idx": plugidx, "energy_data": energy_data, "sensor_data": sensor_data}
 			else:
 				self._tasmota_logger.debug(response)

--- a/octoprint_tasmota/__init__.py
+++ b/octoprint_tasmota/__init__.py
@@ -2,9 +2,9 @@
 from __future__ import absolute_import
 
 import octoprint.plugin
-from octoprint.access.permissions import Permissions, ADMIN_GROUP, USER_GROUP
+from octoprint.access.permissions import Permissions, ADMIN_GROUP
 from octoprint.util import RepeatedTimer
-from octoprint.events import eventManager, Events
+from octoprint.events import Events
 from flask_babel import gettext
 import time
 import logging
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 
 try:
 	from octoprint.util import ResettableTimer
-except:
+except ImportError:
 	class ResettableTimer(threading.Thread):
 		def __init__(self, interval, function, args=None, kwargs=None, on_reset=None, on_cancelled=None):
 			threading.Thread.__init__(self)
@@ -644,7 +644,7 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 			self._tasmota_logger.debug("Restarting idle timer.")
 			self._reset_idle_timer()
 		elif command == 'getEnergyData':
-			self._logger.info(data);
+			self._logger.info(data)
 			response = {}
 			if "start_date" in data and data["start_date"] != "":
 				start_date = data["start_date"]

--- a/octoprint_tasmota/__init__.py
+++ b/octoprint_tasmota/__init__.py
@@ -603,6 +603,9 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 			if chk.upper() in ["ON", "1"]:
 				response = {"currentState": "on", "ip": plugip, "idx": plugidx, "energy_data": energy_data,
 							"sensor_data": sensor_data}
+				if self._settings.get_boolean(["powerOffWhenIdle"]) and plug["automaticShutdownEnabled"] and self._abort_timer is None and (self._idleTimer is None or not self._idleTimer.is_alive()):
+					self._tasmota_logger.debug("Starting idle timer since ON state was detected for %s:%s" % (plugip, plugidx))
+					self._reset_idle_timer()
 			elif chk.upper() in ["OFF", "0"]:
 				response = {"currentState": "off", "ip": plugip, "idx": plugidx, "energy_data": energy_data,
 							"sensor_data": sensor_data}

--- a/octoprint_tasmota/__init__.py
+++ b/octoprint_tasmota/__init__.py
@@ -526,10 +526,19 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 				if energy_data is not None:
 					today = datetime.today()
 					c = self.lookup(response, *["StatusSNS", "ENERGY", "Current"])
+					if isinstance(c, list):
+						c = c[int(plugidx)-1]
 					p = self.lookup(response, *["StatusSNS", "ENERGY", "Power"])
+					if isinstance(p, list):
+						p = p[int(plugidx)-1]
 					t = self.lookup(response, *["StatusSNS", "ENERGY", "Total"])
+					if isinstance(t, list):
+						t = t[int(plugidx)-1]
 					v = self.lookup(response, *["StatusSNS", "ENERGY", "Voltage"])
+					if isinstance(v, list):
+						v = v[int(plugidx)-1]
 					self._tasmota_logger.debug("Energy Data: %s" % energy_data)
+					self._logger.debug("Inserting data: {} : {}".format(["ip", "idx", "timestamp", "current", "power", "total", "voltage"], [plugip, plugidx, today.isoformat(' '), c, p, t, v]))
 					db = sqlite3.connect(self.energy_db_path)
 					cursor = db.cursor()
 					cursor.execute(

--- a/octoprint_tasmota/__init__.py
+++ b/octoprint_tasmota/__init__.py
@@ -155,26 +155,27 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 	##~~ SettingsPlugin mixin
 
 	def get_settings_defaults(self):
-		return dict(
-			debug_logging=False,
-			polling_enabled=False,
-			polling_interval=5,
-			thermal_runaway_monitoring=False,
-			thermal_runaway_max_bed=120,
-			thermal_runaway_max_extruder=300,
-			event_on_error_monitoring=False,
-			event_on_disconnect_monitoring=False,
-			event_on_connecting_monitoring=False,
-			arrSmartplugs=[],
-			abortTimeout=30,
-			powerOffWhenIdle=False,
-			idleTimeout=30,
-			idleIgnoreCommands='M105',
-			idleTimeoutWaitTemp=50,
-			event_on_upload_monitoring=False,
-			cost_rate=0,
-			request_timeout=3
-		)
+		return {
+			"debug_logging": False,
+			"polling_enabled": False,
+			"polling_interval": 5,
+			"thermal_runaway_monitoring": False,
+			"thermal_runaway_max_bed": 120,
+			"thermal_runaway_max_extruder": 300,
+			"event_on_error_monitoring": False,
+			"event_on_disconnect_monitoring": False,
+			"event_on_connecting_monitoring": False,
+			"arrSmartplugs": [],
+			"abortTimeout": 30,
+			"powerOffWhenIdle": False,
+			"idleTimeout": 30,
+			"idleIgnoreCommands": 'M105',
+			"idleTimeoutWaitTemp": 50,
+			"idleWaitForTimelapse": True,
+			"event_on_upload_monitoring": False,
+			"cost_rate": 0,
+			"request_timeout": 3
+		}
 
 	def on_settings_save(self, data):
 		old_debug_logging = self._settings.get_boolean(["debug_logging"])
@@ -313,7 +314,8 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 					self._tasmota_logger.debug("powering off %s:%s due to %s event." % (plug["ip"], plug["idx"], event))
 					self.turn_off(plug["ip"], plug["idx"])
 
-		if event == Events.CONNECTING and self._settings.get_boolean(["event_on_connecting_monitoring"]) and self._printer.is_closed_or_error:
+		if event == Events.CONNECTING and self._settings.get_boolean(
+				["event_on_connecting_monitoring"]) and self._printer.is_closed_or_error:
 			self._tasmota_logger.debug("powering on due to %s event." % event)
 			for plug in self._settings.get(['arrSmartplugs']):
 				if plug["event_on_connecting"] == True:
@@ -338,7 +340,8 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 		# Printer Connected Event
 		if event == Events.CONNECTED:
 			if self.thermal_runaway_triggered:
-				self._plugin_manager.send_plugin_message(self._identifier, dict(thermal_runaway=True, type="connection"))
+				self._plugin_manager.send_plugin_message(self._identifier,
+														 dict(thermal_runaway=True, type="connection"))
 				self._tasmota_logger.debug("thermal runaway event triggered prior to last connection.")
 				self.thermal_runaway_triggered = False
 			if self._autostart_file:
@@ -370,7 +373,8 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 			self.print_job_started = True
 			self._tasmota_logger.debug(payload.get("path", None))
 			if self.thermal_runaway_triggered:
-				self._plugin_manager.send_plugin_message(self._identifier, dict(thermal_runaway=True, type="connection"))
+				self._plugin_manager.send_plugin_message(self._identifier,
+														 dict(thermal_runaway=True, type="connection"))
 				self._tasmota_logger.debug("thermal runaway event triggered prior to last connection.")
 				self.thermal_runaway_triggered = False
 			for plug in self._settings.get(["arrSmartplugs"]):
@@ -389,7 +393,9 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 			if self._idleTimer is not None:
 				self._reset_idle_timer()
 			self._timeout_value = None
-			self._plugin_manager.send_plugin_message(self._identifier, dict(powerOffWhenIdle=self.powerOffWhenIdle, type="timeout", timeout_value=self._timeout_value))
+			self._plugin_manager.send_plugin_message(self._identifier,
+													 dict(powerOffWhenIdle=self.powerOffWhenIdle, type="timeout",
+														  timeout_value=self._timeout_value))
 
 		# Print Cancelled/Done Events
 		if event == Events.PRINT_DONE and self.print_job_started:
@@ -437,11 +443,16 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 		try:
 			if plug["use_backlog"] and int(plug["backlog_on_delay"]) > 0:
 				backlog_command = "backlog delay {};Power{} on;".format(int(plug["backlog_on_delay"]) * 10, plug["idx"])
-				requests.get("http://{}/cm".format(plugip), params={"user": plug["username"], "password": plug["password"], "cmnd": backlog_command}, timeout=self._settings.get_int(["request_timeout"]))
+				requests.get("http://{}/cm".format(plugip),
+							 params={"user": plug["username"], "password": plug["password"], "cmnd": backlog_command},
+							 timeout=self._settings.get_int(["request_timeout"]))
 				response = dict()
 				response["POWER%s" % plug["idx"]] = "ON"
 			else:
-				webresponse = requests.get("http://{}/cm".format(plugip), params={"user": plug["username"], "password": plug["password"], "cmnd": "Power{} on".format(plug["idx"])}, timeout=self._settings.get_int(["request_timeout"]))
+				webresponse = requests.get("http://{}/cm".format(plugip),
+										   params={"user": plug["username"], "password": plug["password"],
+												   "cmnd": "Power{} on".format(plug["idx"])},
+										   timeout=self._settings.get_int(["request_timeout"]))
 				response = webresponse.json()
 			chk = response["POWER%s" % plug["idx"]]
 		except:
@@ -455,7 +466,8 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 			if plug["autoConnect"] and self._printer.is_closed_or_error():
 				self._logger.info(self._settings.global_get(['serial']))
 				c = threading.Timer(int(plug["autoConnectDelay"]), self._printer.connect,
-									kwargs=dict(port=self._settings.global_get(['serial', 'port']), baudrate=self._settings.global_get(['serial', 'baudrate'])))
+									kwargs=dict(port=self._settings.global_get(['serial', 'port']),
+												baudrate=self._settings.global_get(['serial', 'baudrate'])))
 				c.daemon = True
 				c.start()
 			if plug["sysCmdOn"]:
@@ -467,7 +479,7 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 					"Resetting idle timer since plug %s:%s was just turned on." % (plugip, plugidx))
 				self._waitForHeaters = False
 				self._reset_idle_timer()
-			self._plugin_manager.send_plugin_message(self._identifier, dict(currentState="on",ip=plugip,idx=plugidx))
+			self._plugin_manager.send_plugin_message(self._identifier, dict(currentState="on", ip=plugip, idx=plugidx))
 
 	def turn_off(self, plugip, plugidx):
 		plug = self.plug_search(self._settings.get(["arrSmartplugs"]), "ip", plugip, "idx", plugidx)
@@ -476,8 +488,11 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 			if plug["use_backlog"] and int(plug["backlog_off_delay"]) > 0:
 				self._tasmota_logger.debug(
 					"Using backlog commands with a delay value of %s" % str(int(plug["backlog_off_delay"]) * 10))
-				backlog_command = "backlog delay {};Power{} off;".format(int(plug["backlog_off_delay"]) * 10, plug["idx"])
-				requests.get("http://{}/cm".format(plugip), params={"user": plug["username"], "password": plug["password"], "cmnd": backlog_command}, timeout=self._settings.get_int(["request_timeout"]))
+				backlog_command = "backlog delay {};Power{} off;".format(int(plug["backlog_off_delay"]) * 10,
+																		 plug["idx"])
+				requests.get("http://{}/cm".format(plugip),
+							 params={"user": plug["username"], "password": plug["password"], "cmnd": backlog_command},
+							 timeout=self._settings.get_int(["request_timeout"]))
 				response = dict()
 				response["POWER%s" % plug["idx"]] = "OFF"
 			if plug["sysCmdOff"]:
@@ -492,11 +507,15 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 				time.sleep(int(plug["autoDisconnectDelay"]))
 			if not plug["use_backlog"]:
 				self._tasmota_logger.debug("Not using backlog commands")
-				webresponse = requests.get("http://{}/cm".format(plugip), params={"user": plug["username"], "password": plug["password"], "cmnd": "Power{} off".format(plug["idx"])}, timeout=self._settings.get_int(["request_timeout"]))
+				webresponse = requests.get("http://{}/cm".format(plugip),
+										   params={"user": plug["username"], "password": plug["password"],
+												   "cmnd": "Power{} off".format(plug["idx"])},
+										   timeout=self._settings.get_int(["request_timeout"]))
 				response = webresponse.json()
 			chk = response["POWER%s" % plug["idx"]]
 			if chk.upper() in ["OFF", "0"]:
-				self._plugin_manager.send_plugin_message(self._identifier, dict(currentState="off", ip=plugip, idx=plugidx))
+				self._plugin_manager.send_plugin_message(self._identifier,
+														 dict(currentState="off", ip=plugip, idx=plugidx))
 		except:
 			self._tasmota_logger.error('Invalid ip or unknown error connecting to %s.' % plug["ip"], exc_info=True)
 			response = "Unknown error turning off %s index %s." % (plugip, plugidx)
@@ -513,7 +532,10 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 			try:
 				plug = self.plug_search(self._settings.get(["arrSmartplugs"]), "ip", plugip, "idx", plugidx)
 				self._tasmota_logger.debug(plug)
-				webresponse = requests.get("http://{}/cm".format(plugip), params={"user": plug["username"], "password": plug["password"], "cmnd": "Status 0"}, timeout=self._settings.get_int(["request_timeout"]))
+				webresponse = requests.get("http://{}/cm".format(plugip),
+										   params={"user": plug["username"], "password": plug["password"],
+												   "cmnd": "Status 0"},
+										   timeout=self._settings.get_int(["request_timeout"]))
 				self._tasmota_logger.debug("check status code: {}".format(webresponse.status_code))
 				self._tasmota_logger.debug("check status text: {}".format(webresponse.text))
 				response = webresponse.json()
@@ -527,18 +549,20 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 					today = datetime.today()
 					c = self.lookup(response, *["StatusSNS", "ENERGY", "Current"])
 					if isinstance(c, list):
-						c = c[int(plugidx)-1]
+						c = c[int(plugidx) - 1]
 					p = self.lookup(response, *["StatusSNS", "ENERGY", "Power"])
 					if isinstance(p, list):
-						p = p[int(plugidx)-1]
+						p = p[int(plugidx) - 1]
 					t = self.lookup(response, *["StatusSNS", "ENERGY", "Total"])
 					if isinstance(t, list):
-						t = t[int(plugidx)-1]
+						t = t[int(plugidx) - 1]
 					v = self.lookup(response, *["StatusSNS", "ENERGY", "Voltage"])
 					if isinstance(v, list):
-						v = v[int(plugidx)-1]
+						v = v[int(plugidx) - 1]
 					self._tasmota_logger.debug("Energy Data: %s" % energy_data)
-					self._logger.debug("Inserting data: {} : {}".format(["ip", "idx", "timestamp", "current", "power", "total", "voltage"], [plugip, plugidx, today.isoformat(' '), c, p, t, v]))
+					self._logger.debug("Inserting data: {} : {}".format(
+						["ip", "idx", "timestamp", "current", "power", "total", "voltage"],
+						[plugip, plugidx, today.isoformat(' '), c, p, t, v]))
 					db = sqlite3.connect(self.energy_db_path)
 					cursor = db.cursor()
 					cursor.execute(
@@ -571,24 +595,31 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 
 			self._tasmota_logger.debug("%s index %s is %s" % (plugip, plugidx, chk))
 			if chk.upper() in ["ON", "1"]:
-				response = {"currentState": "on", "ip": plugip, "idx": plugidx, "energy_data": energy_data, "sensor_data": sensor_data}
+				response = {"currentState": "on", "ip": plugip, "idx": plugidx, "energy_data": energy_data,
+							"sensor_data": sensor_data}
 			elif chk.upper() in ["OFF", "0"]:
-				response = {"currentState": "off", "ip": plugip, "idx": plugidx, "energy_data": energy_data, "sensor_data": sensor_data}
+				response = {"currentState": "off", "ip": plugip, "idx": plugidx, "energy_data": energy_data,
+							"sensor_data": sensor_data}
 			else:
 				self._tasmota_logger.debug(response)
-				response = {"currentState": "unknown", "ip": plugip, "idx": plugidx, "energy_data": energy_data, "sensor_data": sensor_data}
+				response = {"currentState": "unknown", "ip": plugip, "idx": plugidx, "energy_data": energy_data,
+							"sensor_data": sensor_data}
 
 			self._plugin_manager.send_plugin_message(self._identifier, response)
 			return response
 
 	def checkSetOption26(self, plugip, username, password):
-		webresponse = requests.get("http://{}/cm".format(plugip), params={"user": username, "password": password, "cmnd": "SetOption26"}, timeout=self._settings.get_int(["request_timeout"]))
+		webresponse = requests.get("http://{}/cm".format(plugip),
+								   params={"user": username, "password": password, "cmnd": "SetOption26"},
+								   timeout=self._settings.get_int(["request_timeout"]))
 		response = webresponse.json()
 		self._tasmota_logger.debug(response)
 		return response
 
 	def setSetOption26(self, plugip, username, password):
-		webresponse = requests.get("http://{}/cm".format(plugip), params={"user": username, "password": password, "cmnd": "SetOption26 ON"}, timeout=self._settings.get_int(["request_timeout"]))
+		webresponse = requests.get("http://{}/cm".format(plugip),
+								   params={"user": username, "password": password, "cmnd": "SetOption26 ON"},
+								   timeout=self._settings.get_int(["request_timeout"]))
 		response = webresponse.json()
 		self._tasmota_logger.debug(response)
 		return response
@@ -611,10 +642,10 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 
 		if command == 'turnOn':
 			self.turn_on("{ip}".format(**data), "{idx}".format(**data))
-			# return flask.jsonify(self.check_status("{ip}".format(**data), "{idx}".format(**data)))
+		# return flask.jsonify(self.check_status("{ip}".format(**data), "{idx}".format(**data)))
 		elif command == 'turnOff':
 			self.turn_off("{ip}".format(**data), "{idx}".format(**data))
-			# return flask.jsonify(self.check_status("{ip}".format(**data), "{idx}".format(**data)))
+		# return flask.jsonify(self.check_status("{ip}".format(**data), "{idx}".format(**data)))
 
 		elif command == 'checkStatus':
 			return flask.jsonify(self.check_status("{ip}".format(**data), "{idx}".format(**data)))
@@ -637,7 +668,10 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 			self._timeout_value = None
 			for plug in self._settings.get(["arrSmartplugs"]):
 				if plug["use_backlog"] and int(plug["backlog_off_delay"]) > 0:
-					webresponse = requests.get("http://{}/cm".format(plug["ip"]), params={"user": plug["username"], "password": plug["password"], "cmnd": "backlog"}, timeout=self._settings.get_int(["request_timeout"]))
+					webresponse = requests.get("http://{}/cm".format(plug["ip"]),
+											   params={"user": plug["username"], "password": plug["password"],
+													   "cmnd": "backlog"},
+											   timeout=self._settings.get_int(["request_timeout"]))
 					self._tasmota_logger.debug("Cleared countdown rules for %s" % plug["ip"])
 					self._tasmota_logger.debug(webresponse)
 			self._tasmota_logger.debug("Power off aborted.")
@@ -701,8 +735,15 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 				if led_data["LEDBrightness"] == -1:
 					led_data["LEDBrightness"] = plug["brightness"]
 				try:
-					requests.get("http://{}/cm".format(plugip), params={"user": plug["username"], "password": plug["password"], "cmnd": "backlog dimmer {}; color2 {},{},{}; white {}; power{} on".format(led_data["LEDBrightness"], led_data["LEDRed"], led_data["LEDGreen"], led_data["LEDBlue"], led_data["LEDWhite"], plug["idx"])}, timeout=self._settings.get_int(["request_timeout"]))
-					self._plugin_manager.send_plugin_message(self._identifier, dict(currentState="on", ip=plug["ip"], idx=plug["idx"], color=led_data))
+					requests.get("http://{}/cm".format(plugip),
+								 params={"user": plug["username"], "password": plug["password"],
+										 "cmnd": "backlog dimmer {}; color2 {},{},{}; white {}; power{} on".format(
+											 led_data["LEDBrightness"], led_data["LEDRed"], led_data["LEDGreen"],
+											 led_data["LEDBlue"], led_data["LEDWhite"], plug["idx"])},
+								 timeout=self._settings.get_int(["request_timeout"]))
+					self._plugin_manager.send_plugin_message(self._identifier,
+															 dict(currentState="on", ip=plug["ip"], idx=plug["idx"],
+																  color=led_data))
 				except Exception as e:
 					self._logger.debug("Error: {}".format(e))
 
@@ -784,7 +825,8 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 					self.thermal_runaway_triggered = True
 				if k.startswith("T") and v[0] > int(self._settings.get(["thermal_runaway_max_extruder"])):
 					self._tasmota_logger.debug("Extruder max temp reached, shutting off plugs.")
-					self._plugin_manager.send_plugin_message(self._identifier, dict(thermal_runaway=True, type="extruder"))
+					self._plugin_manager.send_plugin_message(self._identifier,
+															 dict(thermal_runaway=True, type="extruder"))
 					self.thermal_runaway_triggered = True
 				if self.thermal_runaway_triggered == True:
 					for plug in self._settings.get(['arrSmartplugs']):
@@ -840,7 +882,8 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 
 		if (uptime() / 60) <= (self._settings.get_int(["idleTimeout"])):
 			self._tasmota_logger.debug("Just booted so wait for time sync.")
-			self._tasmota_logger.debug("uptime: {}, comparison: {}".format((uptime() / 60), (self._settings.get_int(["idleTimeout"]))))
+			self._tasmota_logger.debug(
+				"uptime: {}, comparison: {}".format((uptime() / 60), (self._settings.get_int(["idleTimeout"]))))
 			self._reset_idle_timer()
 			return
 
@@ -863,7 +906,7 @@ class tasmotaPlugin(octoprint.plugin.SettingsPlugin,
 			if not self._waitForTimelapse:
 				return False
 
-			if not self._timelapse_active:
+			if not self._timelapse_active or not self._settings.get_boolean(["idleWaitForTimelapse"]):
 				self._waitForTimelapse = False
 				return True
 

--- a/octoprint_tasmota/static/js/tasmota.js
+++ b/octoprint_tasmota/static/js/tasmota.js
@@ -358,7 +358,7 @@ $(function() {
 				self.settings.settings.plugins.tasmota.powerOffWhenIdle(data.powerOffWhenIdle);
 
 				if (data.type == "timeout") {
-					if ((data.timeout_value != null) && (data.timeout_value > 0)) {
+					if ((data.timeout_value != null) && (data.timeout_value > 0) && (typeof(ko.utils.arrayFirst(self.arrSmartplugsStates.items(), function(item){return item.value() == 'on'})) !== 'undefined')) {
 						var progress_percent = Math.floor((data.timeout_value/self.settings.settings.plugins.tasmota.abortTimeout())*100)
 						var progress_class = (progress_percent<25)?'progress-danger':(progress_percent>75)?'progress-success':'progress-warning';
 						self.timeoutPopupOptions.text = '<div class="progress progress-tasmota '+progress_class+'"><div class="bar">'+gettext('Powering Off in ')+' '+data.timeout_value+' '+gettext('secs')+'</div><div class="progress-text" style="clip-path: inset(0 0 0 '+progress_percent+'%);-webkit-clip-path: inset(0 0 0 '+progress_percent+'%);">'+gettext('Powering Off in ')+' '+data.timeout_value+' '+gettext('secs')+'</div></div>';

--- a/octoprint_tasmota/static/js/tasmota.js
+++ b/octoprint_tasmota/static/js/tasmota.js
@@ -503,12 +503,13 @@ $(function() {
 				data: JSON.stringify({
 					command: "checkSetOption26",
 					ip: data.ip(),
+                    idx: data.idx(),
 					username: data.username(),
 					password: data.password()
 				}),
 				contentType: "application/json; charset=UTF-8"
 			}).done(function(response){
-				if(response["SetOption26"] == "OFF"){
+				if(response["SetOption26"] == "OFF" && data.idx() !== '') {
 					var test = confirm("SetOption26 needs to be updated to ON for proper operation. Would you like to set that option now?");
 					if (test) {
 						$.ajax({

--- a/octoprint_tasmota/static/js/tasmota.js
+++ b/octoprint_tasmota/static/js/tasmota.js
@@ -388,12 +388,12 @@ $(function() {
 
 				var tooltip = plug.label();
 				if(data.sensor_data) {
-					for(k in data.sensor_data) {
-						tooltip += '<br>' + k + ': ' + data.sensor_data["k"]
+					for(let k in data.sensor_data) {
+						tooltip += '<br>' + k + ': ' + data.sensor_data[k]
 					}
 				}
 				if(data.energy_data) {
-					for(k in data.energy_data) {
+					for(let k in data.energy_data) {
 						tooltip += '<br>' + k + ': ' + data.energy_data[k]
 					}
 				}

--- a/octoprint_tasmota/templates/tasmota_settings.jinja2
+++ b/octoprint_tasmota/templates/tasmota_settings.jinja2
@@ -176,7 +176,7 @@
 				<label class="control-label">{{ _('Idle Timeout') }}</label>
 				<div class="controls">
 					<div class="input-append" data-toggle="tooltip" data-bind="tooltip: {}" title="{{ _('Amount of time that will lapse before printer is considered idle and relays will be powered off.') }}">
-						<input type="number" class="input-mini text-right" data-bind="value: settings.settings.plugins.tasmota.idleTimeout, enable: settings.settings.plugins.tasmota.powerOffWhenIdle() && settings.settings.plugins.tasmota.powerOffWhenIdle()" disabled />
+						<input type="number" class="input-mini text-right" data-bind="value: settings.settings.plugins.tasmota.idleTimeout, enable: settings.settings.plugins.tasmota.powerOffWhenIdle()" disabled />
 						<span class="add-on">{{ _('mins') }}</span>
 					</div>
 				</div>
@@ -187,7 +187,7 @@
 				<label class="control-label">{{ _('Idle Target Temperature') }}</label>
 				<div class="controls">
 					<div class="input-append" data-toggle="tooltip" data-bind="tooltip: {}" title="{{ _('Power off will be delayed untill all heaters reach this temperature.') }}">
-						<input type="number" class="input-mini text-right" data-bind="value: settings.settings.plugins.tasmota.idleTimeoutWaitTemp, enable: settings.settings.plugins.tasmota.powerOffWhenIdle() && settings.settings.plugins.tasmota.powerOffWhenIdle()" disabled />
+						<input type="number" class="input-mini text-right" data-bind="value: settings.settings.plugins.tasmota.idleTimeoutWaitTemp, enable: settings.settings.plugins.tasmota.powerOffWhenIdle()" disabled />
 						<span class="add-on">{{ _('degs') }}</span>
 					</div>
 				</div>
@@ -197,8 +197,17 @@
 			<div class="control-group">
 				<label class="control-label">{{ _('GCode Commands to Ignore for Idle') }}</label>
 				<div class="controls" data-toggle="tooltip" data-bind="tooltip: {}" title="{{ _('Comma separated list of gcode commands to ignore for determining printer idle state.') }}">
-					<input type="text" class="input-block-level" data-bind="value: settings.settings.plugins.tasmota.idleIgnoreCommands, enable: settings.settings.plugins.tasmota.powerOffWhenIdle() && settings.settings.plugins.tasmota.powerOffWhenIdle()" disabled />
+					<input type="text" class="input-block-level" data-bind="value: settings.settings.plugins.tasmota.idleIgnoreCommands, enable: settings.settings.plugins.tasmota.powerOffWhenIdle()" disabled />
 				</div>
+			</div>
+		</div>
+		<div class="row-fluid" data-bind="visible: settings.settings.plugins.tasmota.powerOffWhenIdle()">
+			<div class="control-group">
+				<div class="controls">
+                    <label class="checkbox">
+					<input type="checkbox" title="{{ _('When enabled idle power off will wait for timelapse to complete before powering off. Uncheck this to not wait, helpful for very long prints and timelapse rendering.') }}" data-toggle="tooltip" data-bind="checked: settings.settings.plugins.tasmota.idleWaitForTimelapse, tooltip: {}" /> {{ _('Wait for Timelapse') }}
+				    </label>
+                </div>
 			</div>
 		</div>
 	</div>

--- a/octoprint_tasmota/templates/tasmota_settings.jinja2
+++ b/octoprint_tasmota/templates/tasmota_settings.jinja2
@@ -186,7 +186,7 @@
 			<div class="control-group span6">
 				<label class="control-label">{{ _('Idle Target Temperature') }}</label>
 				<div class="controls">
-					<div class="input-append" data-toggle="tooltip" data-bind="tooltip: {}" title="{{ _('Power off will be delayed untill all heaters reach this temperature.') }}">
+					<div class="input-append" data-toggle="tooltip" data-bind="tooltip: {}" title="{{ _('Power off will be delayed until all heaters reach this temperature.') }}">
 						<input type="number" class="input-mini text-right" data-bind="value: settings.settings.plugins.tasmota.idleTimeoutWaitTemp, enable: settings.settings.plugins.tasmota.powerOffWhenIdle()" disabled />
 						<span class="add-on">{{ _('degs') }}</span>
 					</div>
@@ -221,7 +221,7 @@
 	<div class="modal-body">
 		<table class="table table-condensed">
 			<tr>
-				<td><div class="control-group" data-bind="css: {error: ip().length == 0}"><div class="controls" data-toggle="tooltip" data-bind="tooltip: {container: '#TasmotaEditor'}" title="{{ _('IP adress of your tasmota device.') }}"><label class="control-label">{{ _('IP') }}</label><input type="text" class="input-block-level" data-bind="value: ip, valueUpdate: 'keyup'" /></div></div></td>
+				<td><div class="control-group" data-bind="css: {error: ip().length == 0}"><div class="controls" data-toggle="tooltip" data-bind="tooltip: {container: '#TasmotaEditor'}" title="{{ _('IP address of your tasmota device.') }}"><label class="control-label">{{ _('IP') }}</label><input type="text" class="input-block-level" data-bind="value: ip, valueUpdate: 'keyup'" /></div></div></td>
 				<td><div class="controls" data-toggle="tooltip" data-bind="tooltip: {container: '#TasmotaEditor'}" title="{{ _('Index of the relay, specifically used for multiple plug relay devices.') }}"><label class="control-label">{{ _('Index') }}</label><input type="number" min="1" class="input-block-level" data-bind="value: idx" /></div></td>
 				<td><div class="controls" data-toggle="tooltip" data-bind="tooltip: {container: '#TasmotaEditor'}" title="{{ _('Name to display on hover of the navbar button.') }}"><label class="control-label">{{ _('Label') }}</label><input type="text" class="input input-small" data-bind="value: label" /></div></td>
 				<td><div class="controls" data-toggle="tooltip" data-bind="tooltip: {container: '#TasmotaEditor'}" title="{{ _('Username to connect to Tasmota web interface if required.') }}"><label class="control-label">{{ _('Username') }}</label><input type="text" class="input-block-level" data-bind="value: username" /></div></td>
@@ -261,7 +261,7 @@
 				</td>
 				<td></td>
 				<td><div class="controls" data-toggle="tooltip" data-bind="tooltip: {container: '#TasmotaEditor'}" title="{{ _('Prompt for confirmation before powering off via the navbar button.') }}"><label class="checkbox"><input type="checkbox" data-bind="checked: displayWarning" /> Warning Prompt</label></div></td>
-				<td><div class="controls" data-toggle="tooltip" data-bind="tooltip: {container: '#TasmotaEditor'}" title="{{ _('Prompt for confimration before powering off when a print is active.') }}"><label class="checkbox"><input type="checkbox" data-bind="checked: warnPrinting" /> Warn While Printing</label></div></td>
+				<td><div class="controls" data-toggle="tooltip" data-bind="tooltip: {container: '#TasmotaEditor'}" title="{{ _('Prompt for confirmation before powering off when a print is active.') }}"><label class="checkbox"><input type="checkbox" data-bind="checked: warnPrinting" /> Warn While Printing</label></div></td>
 				<td></td>
 			</tr>
 			<tr>

--- a/octoprint_tasmota/templates/tasmota_settings.jinja2
+++ b/octoprint_tasmota/templates/tasmota_settings.jinja2
@@ -89,6 +89,12 @@
 					<label class="checkbox">
 					<input type="checkbox" title="{{ _('When enabled auto power on enabled devices when file is uploaded to OctoPrint with the option to automatically start printing.') }}" data-toggle="tooltip" data-bind="checked: settings.settings.plugins.tasmota.event_on_upload_monitoring, tooltip: {}" /> {{ _('Upload Event Monitoring') }}
 					</label>
+					<label class="checkbox" data-bind="visible: settings.settings.plugins.tasmota.event_on_upload_monitoring()" style="margin-left: 20px;">
+					<input type="checkbox" title="{{ _('Enable to auto power on when uploading via the web interface rather than from a Slicer with the option to automatically start.') }}" data-toggle="tooltip" data-bind="checked: settings.settings.plugins.tasmota.event_on_upload_monitoring_always, tooltip: {}" /> {{ _('Include uploads via web interface') }}
+					</label>
+					<label class="checkbox" data-bind="visible: settings.settings.plugins.tasmota.event_on_upload_monitoring_always()" style="margin-left: 20px;">
+					<input type="checkbox" title="{{ _('Enable to automatically start the print after the Tasmota device is powered on and printer auto connects.') }}" data-toggle="tooltip" data-bind="checked: settings.settings.plugins.tasmota.event_on_upload_monitoring_start_print, tooltip: {}" /> {{ _('Automtically start print after on') }}
+					</label>
 				</div>
 			</div>
 		</div>

--- a/octoprint_tasmota/templates/tasmota_settings.jinja2
+++ b/octoprint_tasmota/templates/tasmota_settings.jinja2
@@ -125,8 +125,19 @@
 			<div class="control-group span6">
 				<label class="control-label">{{ _('Cost per kWh') }}</label>
 				<div class="controls">
-					<input type="number" title="{{ _('Amount used to multiply total kWh by to estimate power cost. Leave 0 if you do not have a power reporting device.') }}" data-toggle="tooltip" min="0" step="0.1" class="input input-mini" data-bind="value: settings.settings.plugins.tasmota.cost_rate" />
+					<input type="number" title="{{ _('Amount used to multiply total kWh by to estimate power cost. Leave 0 if you do not have a power reporting device.') }}" data-toggle="tooltip" min="0" step="0.1" class="input input-mini" data-bind="value: settings.settings.plugins.tasmota.cost_rate, tooltip: {}" />
 				</div>
+			</div>
+		</div>
+		<div class="row-fluid">
+			<div class="control-group span6">
+				<label class="control-label">{{ _('Request Timeout') }}</label>
+				<div class="controls">
+                    <div class="input-append" data-toggle="tooltip" data-bind="tooltip: {}" title="{{ _('How many seconds to wait for responses from tasmota device before it is considered offline.') }}">
+					    <input type="number" min="3" class="input input-mini" data-bind="value: settings.settings.plugins.tasmota.request_timeout" />
+                        <span class="add-on">{{ _('secs') }}</span>
+                    </div>
+                </div>
 			</div>
 		</div>
 		<div class="row-fluid">

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,9 @@
 ###
 
 .
+
+setuptools
+OctoPrint
+requests
+Flask
+uptime

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.4rc4"
+plugin_version = "1.0.4rc5"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.3"
+plugin_version = "1.0.4rc1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.4rc5"
+plugin_version = "1.0.4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.4"
+plugin_version = "1.1.0rc1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.4rc2"
+plugin_version = "1.0.4rc3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.4rc1"
+plugin_version = "1.0.4rc2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.1.0rc1"
+plugin_version = "1.1.0rc2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota"
 plugin_name = "OctoPrint-Tasmota"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.4rc3"
+plugin_version = "1.0.4rc4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
- make waiting for timelapse optional, resolves #147
- don't open abort popup when all plugs off, resolves #148, resolves #151
- update documentation and fix some typos in settings, resolves #52
- add optional upload power on and auto start print, resolves #115
- adjust auto start/on connect related code, resolves #149
- fix sensor data extraction for popup, resolves #144
- when status polling and idle timeout are both enabled, if a plug is detected as on start idle timer if not already started, resolves #160