### PR TITLE
Update the readme (Sonoff-Tasmota -> Tasmota)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OctoPrint-Tasmota
 
-This plugin is to control ITead Sonoff devices that have been flashed with [Sonoff-Tasmota](https://github.com/arendst/Sonoff-Tasmota) via web calls.
+This plugin is to control devices that have been flashed with [Tasmota](https://github.com/arendst/Tasmota) via web calls.
 
 **Requires minimum Tasmota firmware version 5.11.0.**
 
@@ -23,7 +23,7 @@ or manually using this URL:
 
 ## Configuration
 
-Once installed go into settings and enter the ip address for your TP-Link Smartplug device. Adjust additional settings as needed.
+Once installed go into settings and enter the ip address for your Tasmota device. Adjust additional settings as needed.
 
 ## Settings Explained
 


### PR DESCRIPTION
The Sonoff-Tasmota firmware has been renamed a long time ago (in v7) to just Tasmota (see the changelog here: https://github.com/arendst/Tasmota/releases/tag/v7.1.0). Also, the Tasmota firmware now supports a variety of devices (almost all ESP8266 and ESP32 based smart devices), not just ITead Sonoff devices, so I've updated the README.md file accordingly.

BTW, it would be great to update the listing on https://plugins.octoprint.org/plugins/tasmota/ too - and I don't mean just renaming the Sonoff-Tasmota to Tasmota there, but include the complete "Settings Explained" section and add a [missing screenshot](https://github.com/jneilliii/OctoPrint-Tasmota/raw/master/settings.png) showing that the plugin has features like "Error Event Monitoring", which is a very useful feature therefore I think should be mentioned also in the plugins repository listing.