### PR TITLE
Enhance dark theme support for Bootstrap popovers in Tasmota plugin

### DIFF
--- a/octoprint_tasmota/static/css/tasmota.css
+++ b/octoprint_tasmota/static/css/tasmota.css
@@ -107,3 +107,25 @@ input[type="datetime-local"].alert-error {
 #navbar_plugin_tasmota a.hide_popover_content + div.popover > div.popover-content {
     display: none;
 }
+
+/* Themeify (dark themes) leaves Bootstrap popovers with their default white
+   background, which is hard to read. Scope to html.themeify so instances
+   without Themeify keep the stock Bootstrap look. */
+html.themeify #navbar_plugin_tasmota div.popover {
+    background-color: #2f3136;
+    color: #dadadc;
+    border-color: #202225;
+}
+html.themeify #navbar_plugin_tasmota div.popover h3.popover-title {
+    background-color: #36393f;
+    color: #fff;
+    border-bottom-color: #202225;
+}
+html.themeify #navbar_plugin_tasmota div.popover div.popover-content {
+    color: #dadadc;
+}
+html.themeify #navbar_plugin_tasmota div.popover .arrow,
+html.themeify #navbar_plugin_tasmota div.popover .arrow:after {
+    border-bottom-color: #2f3136;
+    border-top-color: #2f3136;
+}


### PR DESCRIPTION
**Problem:**

With Themeify's _enable Theme_ Option activated the Navbar Tool Tip of configured devices does not read well.

<img width="468" height="408" alt="Bildschirmfoto 2026-07-10 um 14 43 12" src="https://github.com/user-attachments/assets/dc7e78df-23bd-490e-9a25-fa4238799dc6" />

**Solution:**

Fix white Bootstrap popover on Tasmota navbar buttons when Themeify dark themes are active.

Themeify on

<img width="468" height="408" alt="Bildschirmfoto 2026-07-10 um 14 45 34" src="https://github.com/user-attachments/assets/f0eb3474-f2c0-4210-9b9b-848c4b92e31d" />

Themeify off

<img width="468" height="408" alt="Bildschirmfoto 2026-07-10 um 14 46 20" src="https://github.com/user-attachments/assets/00ecb65b-c3ad-4b33-a758-1412d56f52bc" />

