### PR TITLE
Fix Energy tab not rendering on OctoPrint 2.0

### DIFF
--- a/octoprint_tasmota/static/js/tasmota.js
+++ b/octoprint_tasmota/static/js/tasmota.js
@@ -4,7 +4,7 @@
  * Author: jneilliii
  * License: AGPLv3
  */
-(function() {
+$(function() {
 	function tasmotaViewModel(parameters) {
 		var self = this;
 
@@ -716,4 +716,4 @@
 		["settingsViewModel","loginStateViewModel","filesViewModel"],
 		["#navbar_plugin_tasmota","#settings_plugin_tasmota","#tab_plugin_tasmota","#sidebar_plugin_tasmota_wrapper"]
 	]);
-})();
+});

--- a/octoprint_tasmota/static/js/tasmota.js
+++ b/octoprint_tasmota/static/js/tasmota.js
@@ -4,7 +4,7 @@
  * Author: jneilliii
  * License: AGPLv3
  */
-$(function() {
+(function() {
 	function tasmotaViewModel(parameters) {
 		var self = this;
 
@@ -716,4 +716,4 @@ $(function() {
 		["settingsViewModel","loginStateViewModel","filesViewModel"],
 		["#navbar_plugin_tasmota","#settings_plugin_tasmota","#tab_plugin_tasmota","#sidebar_plugin_tasmota_wrapper"]
 	]);
-});
+})();

--- a/octoprint_tasmota/templates/tasmota_tab.jinja2
+++ b/octoprint_tasmota/templates/tasmota_tab.jinja2
@@ -1,10 +1,10 @@
-<div class="row-fluid" id="tasmota_graph" data-bind="visible: loginState.isUser()"></div>
-<div class="row-fluid" data-bind="visible: loginState.isUser()">
+<div class="row-fluid" id="tasmota_graph" data-bind="visible: loginState.loggedIn()"></div>
+<div class="row-fluid" data-bind="visible: loginState.loggedIn()">
 	<div class="btn-group pull-right">
 		<button class="btn btn-mini" title="Toggle Legend" data-bind="click: toggle_legend,css: { active: legend_visible() }"><i class="fa fa-list"></i></button>
 	</div>
 </div>
-<div class="row-fluid" data-bind="visible: loginState.isUser()">
+<div class="row-fluid" data-bind="visible: loginState.loggedIn()">
 	<div class="span5">
 		<label class="control-label">{{ _('Start') }}</label>
 		<div class="controls" style="position: relative">


### PR DESCRIPTION
Issue:

The Energy tab stayed empty on OctoPrint 2.0.0rc3,

<img width="948" height="403" alt="Bildschirmfoto 2026-07-10 um 15 43 11" src="https://github.com/user-attachments/assets/bc71ac07-f63f-4d3f-89af-f5b22ba8ee41" />

 but worked on 1.11.8.
 
  
 
<img width="948" height="939" alt="Bildschirmfoto 2026-07-10 um 15 40 47" src="https://github.com/user-attachments/assets/9db1bf3a-82e7-4e11-93d8-47ca6e7f07c6" />
 
 Fixed:

<img width="948" height="939" alt="Bildschirmfoto 2026-07-10 um 16 50 32" src="https://github.com/user-attachments/assets/451eaa91-d840-4fca-a283-e3f2c4017a1c" />



Tested on both instances: 2.0.0rc3 (Python 3.13) where the tab was broken, and 1.11.8 (Python 3.10) to confirm compatability.

---
[commit](https://github.com/jneilliii/OctoPrint-Tasmota/pull/218/commits/fdb5fab1bdb2e8d4213f8f01a0a10220ce76d056) **Removed the following:**

_Changed the JS wrapper from $(function() { ... }) to an immediately-invoked function expression (IIFE) so the view model registers without waiting for DOM-ready._

This was not rootcause of graphs not rendering.
